### PR TITLE
The editing of the `log_files.yml` should happen first to prevent race condition.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,4 +15,3 @@
   service:
     name: "{{ papertrail_service_name }}"
     state: "{{ papertrail_service_state }}"
-

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,9 +1,4 @@
 ---
-- name: Configure Papertrail service
-  service:
-    name: "{{ papertrail_service_name }}"
-    state: "{{ papertrail_service_state }}"
-
 - name: Configure Papertrail
   template:
     src: log_files.yml.j2
@@ -15,3 +10,9 @@
     force: true
   notify: restart papertrail
   when: papertrail_managed_conf_file and papertrail_destination_host | length
+
+- name: Configure Papertrail service
+  service:
+    name: "{{ papertrail_service_name }}"
+    state: "{{ papertrail_service_state }}"
+


### PR DESCRIPTION
Hey @gabops 

I was using your role and discovered some weirdness with the `log_files.yml` getting corrupted and the variables being placed incorrectly in the template.  I think the issue has to be starting the remote_syslog service right before editing the file jacks things up.  I modified the order and it seems to be much more stable.