### PR TITLE
Add support for arm architecture

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-papertrail_version: "0.20"
+papertrail_version: "0.21"
 
 papertrail_service_enabled: true
 

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,8 +1,18 @@
 ---
-- name: Set installer arquitecture
+- name: Set installer architecture for x86
   set_fact:
     papertrail_installer_arch: "amd64"
   when: ansible_architecture == "x86_64"
+
+- name: Set installer architecture for Debian arm
+  set_fact:
+    papertrail_installer_arch: "arm64"
+  when: ansible_architecture == "aarch64" and ansible_os_family == "Debian"
+
+- name: Set installer architecture for RedHat arm
+  set_fact:
+    papertrail_installer_arch: "aarch64"
+  when: ansible_architecture == "aarch64" and ansible_os_family == "RedHat"
 
 - name: Include os family variables
   include_vars:


### PR DESCRIPTION
This PR adds ARM support, so this role can be used to install papertrail log collected on ARM instances.